### PR TITLE
fix: ページ遷移時に前ページのpreviewをすべて消す

### DIFF
--- a/codeBlock.ts
+++ b/codeBlock.ts
@@ -1,4 +1,5 @@
-export type Blocks<Line extends { id: string; text: string }> = Line[][];
+export type Blocks<Line extends { id: string; text: string }> =
+  readonly Line[][];
 
 export interface CodeBlock<Line extends { id: string; text: string }> {
   filename: string;

--- a/previewers/TikZ/renderToSVG.ts
+++ b/previewers/TikZ/renderToSVG.ts
@@ -32,9 +32,7 @@ export const renderToSVG = (
 };
 
 const init = async (workerURL: string | URL, zippedAssetURL: string | URL) => {
-  const worker = new Worker(workerURL, {
-    type: "module",
-  });
+  const worker = new Worker(workerURL, { type: "module" });
   const initialized = new Promise<void>((resolve) => {
     const callback = (e: MessageEvent<WorkerResult>) => {
       if (e.data.type !== "asset-url") return;

--- a/readCodeBlocks.ts
+++ b/readCodeBlocks.ts
@@ -8,7 +8,7 @@ import { Blocks } from "./codeBlock.ts";
 export const readCodeBlocks = <Line extends { id: string; text: string }>(
   lines: readonly Line[],
 ): Map<string, Blocks<Line>> => {
-  const codeBlocks = new Map<string, Blocks<Line>>();
+  const codeBlocks = new Map<string, Line[][]>();
   if (lines.length === 0) return codeBlocks;
   const packs = packRows(
     parseToRows(lines.map((line) => line.text).join("\n")),


### PR DESCRIPTION
debounceをpreviewにのみ適用した